### PR TITLE
Implement minimal MCP server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# MCP Experiment
+
+This repository contains a minimal example of a Model Context Protocol (MCP) server implemented with FastAPI. The server exposes a single tool named `favorite_number` which always returns the string `"Lauren's favorite number is 13"`.
+
+## Running the server
+
+Install dependencies using `poetry` and run the application with `uvicorn`:
+
+```bash
+poetry install
+poetry run uvicorn mcp_experiment.server:app --reload
+```
+
+The server will start on `http://127.0.0.1:8000`.
+
+## Endpoints
+
+- `GET /handshake` – returns MCP handshake information including available tools.
+- `POST /execute` – execute a tool by name.
+
+Example request to execute the tool:
+
+```bash
+curl -X POST http://127.0.0.1:8000/execute \
+  -H "Content-Type: application/json" \
+  -d '{"tool": "favorite_number"}'
+```
+
+Response:
+
+```json
+{"result": "Lauren's favorite number is 13"}
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+    "fastapi",
+    "uvicorn",
 ]
 
 [tool.poetry]

--- a/src/mcp_experiment/__init__.py
+++ b/src/mcp_experiment/__init__.py
@@ -1,0 +1,3 @@
+from .server import app
+
+__all__ = ["app"]

--- a/src/mcp_experiment/server.py
+++ b/src/mcp_experiment/server.py
@@ -1,0 +1,32 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI(title="Favorite Number MCP Server")
+
+class ToolInvocation(BaseModel):
+    tool: str
+    args: dict | None = None
+
+@app.get("/handshake")
+def handshake():
+    return {
+        "name": "FavoriteNumberServer",
+        "mcp_version": "0.1",
+        "tools": [
+            {
+                "name": "favorite_number",
+                "description": "Return Lauren's favorite number",
+                "parameters": {}
+            }
+        ]
+    }
+
+@app.post("/execute")
+def execute(invocation: ToolInvocation):
+    if invocation.tool == "favorite_number":
+        return {"result": "Lauren's favorite number is 13"}
+    return {"error": "Unknown tool"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- add a FastAPI-based MCP server exposing the `favorite_number` tool
- describe usage in README
- include FastAPI and uvicorn in dependencies
- export app from package for running

## Testing
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_683b7faec5288325b1d7bff1fd58a574